### PR TITLE
Introduce more verbose output for the WP-CLI command

### DIFF
--- a/inc/class-enrich.php
+++ b/inc/class-enrich.php
@@ -33,8 +33,7 @@ class Enrich {
 	 * @return bool
 	 */
 	public static function generate_alt_text_if_none_exists( $attachment_id ) {
-		$alt_text = get_post_meta( $attachment_id, self::ALT_TEXT_META_KEY, true );
-		if ( '' !== $alt_text ) {
+		if ( '' !== self::get_attachment_alt_text( $attachment_id ) ) {
 			return false;
 		}
 		return self::generate_alt_text_always( $attachment_id );
@@ -47,9 +46,8 @@ class Enrich {
 	 * @return bool
 	 */
 	public static function generate_alt_text_if_missing_or_previously_enriched( $attachment_id ) {
-		$enriched = get_post_meta( $attachment_id, self::ENRICHED_META_KEY, true );
-		$alt_text = get_post_meta( $attachment_id, self::ALT_TEXT_META_KEY, true );
-		if ( '' === $alt_text || $enriched ) {
+		if ( '' === self::get_attachment_alt_text( $attachment_id )
+			|| self::is_attachment_enriched( $attachment_id ) ) {
 			return self::generate_alt_text_always( $attachment_id );
 		}
 		return false;
@@ -114,6 +112,26 @@ class Enrich {
 		}
 		$likely_violations = array_unique( $likely_violations );
 		return $likely_violations;
+	}
+
+	/**
+	 * Get the alt text for an attachment.
+	 *
+	 * @param integer $attachment_id ID for the attachment.
+	 * @return string
+	 */
+	public static function get_attachment_alt_text( $attachment_id ) {
+		return get_post_meta( $attachment_id, self::ALT_TEXT_META_KEY, true );
+	}
+
+	/**
+	 * Whether or not the attachment is enriched.
+	 *
+	 * @param integer $attachment_id ID for the attachment.
+	 * @return boolean
+	 */
+	public static function is_attachment_enriched( $attachment_id ) {
+		return (bool) get_post_meta( $attachment_id, self::ENRICHED_META_KEY, true );
 	}
 
 }

--- a/tests/test-enrich.php
+++ b/tests/test-enrich.php
@@ -18,7 +18,8 @@ class EnrichTest extends Pantheon_Image_Enrichment_Testcase {
 	public function test_generate_alt_text_for_attachment_when_missing() {
 		$file          = dirname( __FILE__ ) . '/data/canola.jpg';
 		$attachment_id = $this->create_upload_object( $file );
-		$this->assertEquals( 'yellow, rapeseed, field, canola, grassland, mustard plant, plain, prairie, mustard and cabbage family, sky', get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) );
+		$this->assertEquals( 'yellow, rapeseed, field, canola, grassland, mustard plant, plain, prairie, mustard and cabbage family, sky', Enrich::get_attachment_alt_text( $attachment_id ) );
+		$this->assertTrue( Enrich::is_attachment_enriched( $attachment_id ) );
 	}
 
 	/**
@@ -27,8 +28,10 @@ class EnrichTest extends Pantheon_Image_Enrichment_Testcase {
 	public function test_generate_alt_text_refresh() {
 		$file          = dirname( __FILE__ ) . '/data/canola.jpg';
 		$attachment_id = $this->create_upload_object( $file );
-		$ret           = Enrich::generate_alt_text_if_missing_or_previously_enriched( $attachment_id );
+		$this->assertTrue( Enrich::is_attachment_enriched( $attachment_id ) );
+		$ret = Enrich::generate_alt_text_if_missing_or_previously_enriched( $attachment_id );
 		$this->assertTrue( $ret );
+		$this->assertTrue( Enrich::is_attachment_enriched( $attachment_id ) );
 	}
 
 	/**
@@ -37,9 +40,12 @@ class EnrichTest extends Pantheon_Image_Enrichment_Testcase {
 	public function test_generate_alt_text_no_refresh_when_customized() {
 		$file          = dirname( __FILE__ ) . '/data/canola.jpg';
 		$attachment_id = $this->create_upload_object( $file );
+		$this->assertTrue( Enrich::is_attachment_enriched( $attachment_id ) );
 		update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'My custom alt text' );
+		$this->assertFalse( Enrich::is_attachment_enriched( $attachment_id ) );
 		$ret = Enrich::generate_alt_text_if_missing_or_previously_enriched( $attachment_id );
 		$this->assertFalse( $ret );
+		$this->assertFalse( Enrich::is_attachment_enriched( $attachment_id ) );
 	}
 
 	/**
@@ -48,9 +54,9 @@ class EnrichTest extends Pantheon_Image_Enrichment_Testcase {
 	public function test_remove_enrichment_flag_when_alt_text_is_updated() {
 		$file          = dirname( __FILE__ ) . '/data/canola.jpg';
 		$attachment_id = $this->create_upload_object( $file );
-		$this->assertTrue( (bool) get_post_meta( $attachment_id, Enrich::ENRICHED_META_KEY, true ) );
+		$this->assertTrue( Enrich::is_attachment_enriched( $attachment_id ) );
 		update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'My custom alt text' );
-		$this->assertFalse( (bool) get_post_meta( $attachment_id, Enrich::ENRICHED_META_KEY, true ) );
+		$this->assertFalse( Enrich::is_attachment_enriched( $attachment_id ) );
 	}
 
 	/**


### PR DESCRIPTION
```
$ wp pantheon image generate-alt-text --refresh
Generated alt text for image #3: wine, drink, alcoholic beverage, bottle, glass bottle, liqueur, distilled beverage, wine bottle, wine glass, red wine
Warning: Skipping image #2 because it is unenriched.
Success: Enriched 1 of 2 images (1 skipped).
```